### PR TITLE
[CI] (tools) Fix Dependabot And Fix Commit Analysis

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,8 @@
 version: 2
 updates:
     - package-ecosystem: "github-actions"
+      commit-message:
+          prefix: "[AUTO]"
       directory: "/"
       schedule:
           interval: "weekly"
@@ -16,6 +18,8 @@ updates:
                   - patch
 
     - package-ecosystem: "npm"
+      commit-message:
+          prefix: "[AUTO]"
       directory: "/"
       schedule:
           interval: "weekly"

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -40,4 +40,4 @@ PR titles should follow the same rules as commit messages to the branch they're 
 | `REFACTOR`  | None          | Changes to the code that don't change its logic. |
 | `TEST`      | None          | Changes relating to the tests                    |
 | `CI`        | Minor (0.X.0) | Changes relating to CI/CD                        |
-| `AUTO`      | None          | Changes my by the CI/CD                          |
+| `AUTO`      | None          | Changes by the CI/CD                             |

--- a/tools/utils/types/constructors/versioning/title.ts
+++ b/tools/utils/types/constructors/versioning/title.ts
@@ -1,9 +1,16 @@
 import type { AcceptedTitleScope, AcceptedTitleType } from "../../../../types/versioning/title.js";
+import { acceptedTitleScopes, acceptedTitleTypes } from "../../../../versioning/constants.js";
 
 export function makeAcceptedTitleType(titleType: string): AcceptedTitleType {
+    if (!(acceptedTitleTypes as readonly string[]).includes(titleType)) {
+        throw new Error(`Received Invalid Title Type: ${titleType}`);
+    }
     return titleType as AcceptedTitleType;
 }
 
 export function makeAcceptedTitleScope(titleScope: string): AcceptedTitleScope {
+    if (!(acceptedTitleScopes as readonly string[]).includes(titleScope)) {
+        throw new Error(`Received Invalid Title Type: ${titleScope}`);
+    }
     return titleScope as AcceptedTitleScope;
 }

--- a/tools/versioning/commit-lint.ts
+++ b/tools/versioning/commit-lint.ts
@@ -1,5 +1,3 @@
-import * as core from "@actions/core";
-
 import type { GitHubCommitSHA } from "../types/github/commits.js";
 import type { AcceptedBump, AcceptedTitleScope, ParsedTitle, TitleParam } from "../types/versioning/title.js";
 import { getCommitMessage, getCommitSha } from "../utils/github/commits.js";
@@ -17,7 +15,6 @@ export async function lintCommit(
     const scope = getCommitTitleScope(parsedTitle, titleParam);
     const bumpType = getCommitBumpType(titleParam);
 
-    core.info(`✅ Commit Message Valid. Bump Type: ${bumpType}, Scope: ${scope}`);
     return { bumpType, scope };
 }
 

--- a/tools/versioning/title-parsing.ts
+++ b/tools/versioning/title-parsing.ts
@@ -6,7 +6,7 @@ import {
     makeAcceptedTitleType,
 } from "../utils/types/constructors/versioning/title.js";
 
-const titlePattern = /(?<type>\[[A-Z]+\]) (?<scope>\([a-z]+\) )?(?<message>.+)/;
+const titlePattern = /\[(?<type>[A-Z]+)\] (?:\((?<scope>[a-z]+ )\))?(?<message>.+)/;
 
 export function isValidTitle(title: string): boolean {
     return titlePattern.test(title);


### PR DESCRIPTION
the dependabot wasn't prefixing [AUTO], and the commit analysis had a wrong regex, plus wasn't validating inputs properly either.